### PR TITLE
BG-187 - Edges are stored forever in metadata.json

### DIFF
--- a/src/utils/CommonUtils.js
+++ b/src/utils/CommonUtils.js
@@ -370,7 +370,7 @@ class CommonUtils {
 	 * @param func {function}
 	 * @param retries {number|null}
 	 * @param sleepTimeFunc {function} time
-	 * @returns {*} funtion result
+	 * @returns {*} function result
 	 * @throws {string} final fail if all retries expired
 	 */
 	static async retry(func, retries = 5, sleepTimeFunc = CommonUtils.exponentialTimeWithJitter) {


### PR DESCRIPTION
Took advantage of the already existing 'resolveDns' function and the 'await promise.all' to add the edge lookup call (this way it stays parallel and takes less time)

Can be tested by running  'beame servers runHelloWorldServer --fqdn some_fqdn'